### PR TITLE
Update README with correct auth params

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Query examples
 from humio_api.humio_api import HumioApi
 
 # Init the API
-api = HumioApi(baseUrl='https://cloud.humio.com', dataspace='<YOUR_DATASPACE>',
+api = HumioApi(baseUrl='https://cloud.humio.com', repo='<YOUR_REPO>',
                token='<YOUR_TOKEN>')
 
 # creating query
@@ -42,7 +42,7 @@ User management examples (only for local on prem install)
 from humio_api.humio_api import HumioApi
 
 # Init the API
-h = HumioApi(baseUrl='https://cloud.humio.com', dataspace='<YOUR_DATASPACE>',
+h = HumioApi(baseUrl='https://cloud.humio.com', repo='<YOUR_REPO>',
              token='<YOUR_TOKEN>')
 
 # Get all users
@@ -67,7 +67,7 @@ Data ingest examples
 from humio_api.humio_api import HumioApi
 
 # Init the API
-h = HumioApi(baseUrl='https://cloud.humio.com', dataspace='<YOUR_DATASPACE>',
+h = HumioApi(baseUrl='https://cloud.humio.com', repo='<YOUR_REPO>',
              token='<YOUR_TOKEN>')
 
 # some test data


### PR DESCRIPTION
The `dataspace` parameter was renamed to `repo`. The examples files were updated, but the README was not.