### PR TITLE
Fix empty initial results on streaming queries

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,18 +77,23 @@ It is mainly used for performing queries, as well as managing different aspects 
        repository= "sandbox",
        user_token="*****")
  
-  # Using a streaming query
-  webStream = client.streaming_query("timechart()")
+  # Using a streaming query 
+  webStream = client.streaming_query("Login Attempt Failed", is_live=True)
   for event in webStream:
       print(event)
  
-  # Using a queryjob
-  queryjob = client.create_queryjob("timechart()")
+  # Using a queryjob 
+  queryjob = client.create_queryjob("Login Attempt Failed", is_live=True)
+  poll_result = queryjob.poll()
+  for event in poll_result.events:
+      print(event)
+
+  # With a static queryjob you can poll it iterativly until it has been exhausted
+  queryjob = client.create_queryjob("Login Attempt Failed", is_live=False)
   for poll_result in queryjob.poll_until_done():
       print(poll_result.metadata)
       for event in poll_result.events:
               print(event)
- 
  
 HumioIngestClient
 *****************

--- a/src/humiolib/QueryJob.py
+++ b/src/humiolib/QueryJob.py
@@ -120,10 +120,17 @@ class BaseQueryJob():
 
         poll_result = self._fetch_next_segment(link, headers, **kwargs)
         
-        # If an aggregate query has not completed, the unfinished result will be returned.
-        # We choose to be opinionated on this and query Humio until such a query is done.
-        while self._aggregate_query_is_not_done(poll_result.metadata):
-            poll_result = self._fetch_next_segment(link, headers, **kwargs)
+        if poll_result.metadata["isAggregate"]:
+            # If an aggregate query has not completed, the unfinished result will be returned.
+            # We choose to be opinionated on this and query Humio until such a query is done.
+            while self._aggregate_query_is_not_done(poll_result.metadata):
+                poll_result = self._fetch_next_segment(link, headers, **kwargs)
+        
+        # Streaming
+        else:
+            if poll_result.metadata["workDone"] == 0 and not self.is_done:
+                poll_result = self._fetch_next_segment(link, headers, **kwargs)
+
 
         return poll_result
     

--- a/src/humiolib/QueryJob.py
+++ b/src/humiolib/QueryJob.py
@@ -29,10 +29,11 @@ class BaseQueryJob():
         user_token (string): Token used to access resource
         """
         self.query_id = query_id
-        self.is_done = False
-        self.is_cancelled = False
+        self.segment_is_done = False
+        self.segment_is_cancelled = False
+        self.more_segments_can_be_polled = True
         self.time_at_last_poll = 0
-        self.wait_time = 0
+        self.wait_time_until_next_poll = 0
         self.base_url = base_url
         self.repository = repository
         self.user_token = user_token
@@ -56,8 +57,8 @@ class BaseQueryJob():
         This will always pass on the first poll to the queryjob.
         """
         time_since_last_poll = time.time() - self.time_at_last_poll
-        if(time_since_last_poll < self.wait_time):
-            time.sleep((self.wait_time - time_since_last_poll) / 1000.0) 
+        if(time_since_last_poll < self.wait_time_until_next_poll):
+            time.sleep((self.wait_time_until_next_poll - time_since_last_poll) / 1000.0) 
 
     def _fetch_next_segment(self, link, headers, **kwargs):
         """
@@ -87,24 +88,24 @@ class BaseQueryJob():
             else:
                 raise e
 
-        self.wait_time = response["metaData"]["pollAfter"]
-        self.is_done = response["done"] 
-        self.is_cancelled = response["cancelled"]
+        self.wait_time_until_next_poll = response["metaData"]["pollAfter"]
+        self.segment_is_done = response["done"] 
+        self.segment_is_cancelled = response["cancelled"]
         self.time_at_last_poll = time.time()
 
         return PollResult(response["events"], response["metaData"])
 
-    def _aggregate_query_is_not_done(self, metadata):
+    def _is_streaming_query(self, metadata):
         """
-        Checks to see if a given aggregate query has been completed
+        Checks whether the query is a streaming query and not an aggregate
 
-        :param metadata: poll result metadata.
+        :param metaData: query response metadata.
         :type metadata: dict
 
-        :return: Answer question posed
-        :rtype: bool
+        :return: Answer to whether query is of type streaming
+        :rtype: Bool
         """
-        return metadata["isAggregate"] and metadata["workDone"] != metadata["totalWork"]
+        return not metadata["isAggregate"]
 
     def poll(self, **kwargs):
         """
@@ -119,29 +120,15 @@ class BaseQueryJob():
         headers.update(kwargs.pop("headers", {}))
 
         poll_result = self._fetch_next_segment(link, headers, **kwargs)
-        
-        if poll_result.metadata["isAggregate"]:
-            # If an aggregate query has not completed, the unfinished result will be returned.
-            # We choose to be opinionated on this and query Humio until such a query is done.
-            while self._aggregate_query_is_not_done(poll_result.metadata):
-                poll_result = self._fetch_next_segment(link, headers, **kwargs)
-        
-        # Streaming
-        else:
-            if poll_result.metadata["workDone"] == 0 and not self.is_done:
-                poll_result = self._fetch_next_segment(link, headers, **kwargs)
-
+        while not self.segment_is_done: # In case the segment hasn't been completed, we poll until is is
+            poll_result = self._fetch_next_segment(link, headers, **kwargs)
+    
+        if self._is_streaming_query(poll_result.metadata):
+            self.more_segments_can_be_polled = poll_result.metadata["extraData"]["hasMoreEvents"] == 'true'
+        else: # is aggregate query
+            self.more_segments_can_be_polled = False
 
         return poll_result
-    
-    def poll_until_done(self):
-        """
-        Create generator for yielding poll results
-
-        :return: A generator for query results
-        :rtype: Generator
-        """
-        yield self.poll()
 
 
 class StaticQueryJob(BaseQueryJob):
@@ -168,9 +155,22 @@ class StaticQueryJob(BaseQueryJob):
         :return: A data object that contains events of the polled segment and metadata about the poll
         :rtype: PollResult
         """
-        if self.is_done:
+        if not self.more_segments_can_be_polled:
             raise HumioQueryJobExhaustedException()
+        
         return super().poll()
+
+    def poll_until_done(self):
+        """
+        Create generator for yielding poll results
+
+        :return: A generator for query results
+        :rtype: Generator
+        """
+
+        yield self.poll()
+        while self.more_segments_can_be_polled:
+            yield self.poll()
 
 
 class LiveQueryJob(BaseQueryJob):
@@ -200,5 +200,5 @@ class LiveQueryJob(BaseQueryJob):
             headers = self._default_user_headers
             endpoint = "dataspaces/{}/queryjobs/{}".format(self.repository, self.query_id)
             self.webcaller.call_rest("delete", endpoint, headers)
-        except HumioHTTPException: # If the queryjob doesn't exists, we don't want to halt on the exception
+        except HumioHTTPException: # If the queryjob doesn't exists anymore, we don't want to halt on the exception
             pass 

--- a/src/humiolib/WebCaller.py
+++ b/src/humiolib/WebCaller.py
@@ -21,6 +21,7 @@ class WebCaller:
         self.base_url = base_url
         self.rest_url = "{}/api/{}/".format(self.base_url, self.version_number_humio)
         self.graphql_url = "{}/graphql".format(self.base_url)
+        self.session = requests.Session()
 
     def call_rest(self, verb, endpoint, headers=None, data=None, files=None, stream=False, **kwargs):
         """
@@ -83,7 +84,7 @@ class WebCaller:
         :rtype: Response Object
         """
         try:
-            response = requests.request(
+            response = self.session.request(
                 verb, link, data=data, headers=headers, stream=stream, files=files, **kwargs
             )
             response.raise_for_status()

--- a/src/humiolib/WebCaller.py
+++ b/src/humiolib/WebCaller.py
@@ -21,7 +21,7 @@ class WebCaller:
         self.base_url = base_url
         self.rest_url = "{}/api/{}/".format(self.base_url, self.version_number_humio)
         self.graphql_url = "{}/graphql".format(self.base_url)
-        self.session = requests.Session()
+
 
     def call_rest(self, verb, endpoint, headers=None, data=None, files=None, stream=False, **kwargs):
         """
@@ -84,7 +84,7 @@ class WebCaller:
         :rtype: Response Object
         """
         try:
-            response = self.session.request(
+            response = requests.request(
                 verb, link, data=data, headers=headers, stream=stream, files=files, **kwargs
             )
             response.raise_for_status()

--- a/tests/test_queryjob.py
+++ b/tests/test_queryjob.py
@@ -61,8 +61,8 @@ def test_poll_until_done_live_queryjob_aggregate_query(humioclient):
     queryjob = humioclient.create_queryjob("timechart()", is_live=True)
     
     events = []
-    for pollResult in queryjob.poll_until_done():
-        events.extend(pollResult.events)
+    for poll_events in queryjob.poll().events:
+        events.extend(poll_events)
     
     assert len(events) != 0
 
@@ -71,8 +71,8 @@ def test_poll_until_done_live_queryjob_non_aggregate_query(humioclient):
     queryjob = humioclient.create_queryjob("", is_live=True)
     
     events = []
-    for pollResult in queryjob.poll_until_done():
-        events.extend(pollResult.events)
+    for poll_events in queryjob.poll().events:
+        events.extend(poll_events)
     
     assert len(events) != 0
 
@@ -81,11 +81,11 @@ def test_poll_until_done_live_queryjob_poll_after_done_success(humioclient):
     queryjob = humioclient.create_queryjob("timechart()", is_live=True)
     
     first_poll_events = []
-    for pollResult in queryjob.poll_until_done():
-        first_poll_events.extend(pollResult.events)
+    for poll_events in queryjob.poll().events:
+        first_poll_events.extend(poll_events)
 
     second_poll_events = []
-    for pollResult in queryjob.poll_until_done():
-        second_poll_events.extend(pollResult.events)
+    for poll_events in queryjob.poll().events:
+        second_poll_events.extend(poll_events)
         
     assert len(second_poll_events) != 0


### PR DESCRIPTION
# <Feature Title>

**What Changes Have Been Made?**
* Fixed a bug, where poll_until_done would return an empty result if the query job hadn't started up. Will now wait for an initial batch of data to be returned. 

* Fixed a bug, where only the first segment of results from a static query job will be returned. Now poll_until_done will return all segments.

* Removed the poll_until_done method from live queries, as this doesn't make sense for live queries.

**Why Have the Changes Been Made?**
The changes have been introduced so users can be sure to get all their result data from their static queries.

**How Do These Changes Impact the User?**
Live queries using the poll_until_done method will have to be redone in the calling code.
