### PR TITLE
Incorrect parameter in comment

### DIFF
--- a/src/humiolib/HumioClient.py
+++ b/src/humiolib/HumioClient.py
@@ -185,8 +185,8 @@ class HumioClient(BaseHumioClient):
         :type end: Union[int, str], optional
         :param is_live: Ending time of query
         :type is_live: bool, optional
-        :param is_live: Timezone offset in minutes
-        :type is_live: int, optional
+        :param timezone_offset_minutes: Timezone offset in minutes
+        :type timezone_offset_minutes: int, optional
         :param argument: Arguments specified in query
         :type argument: dict(string->string), optional
         :param raw_data: Additional arguments to add to POST body under other keys


### PR DESCRIPTION
# Documentation incorrect parameter name

**What Changes Have Been Made?**

Changed variable name in the comment parameter section, to self update the documentation here: https://python-humio.readthedocs.io/en/latest/reference/humioclient.html

**Why Have the Changes Been Made?**

Documentation parameter name was likely a copy paste duplication issue, where the parameter name was not renamed.

**How Do These Changes Impact the User?**

Corrects the documentation in the URL previously mentioned.