### PR TITLE
Fix urls in docstrings in HumioClient.py

### DIFF
--- a/src/humiolib/HumioClient.py
+++ b/src/humiolib/HumioClient.py
@@ -613,7 +613,7 @@ class HumioIngestClient(BaseHumioClient):
     def _ingest_json_data(self, json_elements=None, **kwargs):
         """
         Ingest structured json data to repository.
-        Structure of ingested data is discussed in: https://docs.humio.com/api/ingest/#structured-data
+        Structure of ingested data is discussed in: https://docs.humio.com/reference/api/ingest/#structured-data
 
         :param json_elements: Structured data that can be parsed to a json string.
         :type json_elements: str
@@ -642,7 +642,7 @@ class HumioIngestClient(BaseHumioClient):
     ):
         """
         Ingest unstructred messages to repository.
-        Structure of ingested data is discussed in: https://docs.humio.com/api/ingest/#structured-data
+        Structure of ingested data is discussed in: https://docs.humio.com/reference/api/ingest/#parser
 
         :param messages: A list of event strings.
         :type messages: list(string), optional

--- a/src/humiolib/HumioClient.py
+++ b/src/humiolib/HumioClient.py
@@ -285,7 +285,7 @@ class HumioClient(BaseHumioClient):
     def _ingest_json_data(self, json_elements=None, **kwargs):
         """
         Ingest structured json data to repository.
-        Structure of ingested data is discussed in: https://docs.humio.com/api/ingest/#structured-data
+        Structure of ingested data is discussed in: https://docs.humio.com/reference/api/ingest/#structured-data
 
         :param messages: A list of event strings.
         :type messages: list(string), optional
@@ -320,6 +320,7 @@ class HumioClient(BaseHumioClient):
     ):
         """
         Ingest unstructred messages to repository.
+        Structure of ingested data is discussed in: https://docs.humio.com/reference/api/ingest/#parser
 
         :param messages: A list of event strings.
         :type messages: list(string), optional


### PR DESCRIPTION
This is very small matter so I didn't make a bug report for it first.

**What Changes Have Been Made?**

The url in the docstring to all `_ingest_json_data` and all `_ingest_messages` in `HumioClient.py`, they're now pointing to the currently valid documentation urls.

**Why Have the Changes Been Made?**

The structure of the docs at humio.com had changed without redirections put in place, so existing links became 404.

**How Do These Changes Impact the User?**

The user will be able to go directly from the humiolib docs to the humio API docs when wanting to know more about ingesting data.