### PR TITLE
Propagates kwargs to poll functions

### DIFF
--- a/src/humiolib/QueryJob.py
+++ b/src/humiolib/QueryJob.py
@@ -158,9 +158,9 @@ class StaticQueryJob(BaseQueryJob):
         if not self.more_segments_can_be_polled:
             raise HumioQueryJobExhaustedException()
         
-        return super().poll()
+        return super().poll(**kwargs)
 
-    def poll_until_done(self):
+    def poll_until_done(self, **kwargs):
         """
         Create generator for yielding poll results
 
@@ -168,9 +168,9 @@ class StaticQueryJob(BaseQueryJob):
         :rtype: Generator
         """
 
-        yield self.poll()
+        yield self.poll(**kwargs)
         while self.more_segments_can_be_polled:
-            yield self.poll()
+            yield self.poll(**kwargs)
 
 
 class LiveQueryJob(BaseQueryJob):


### PR DESCRIPTION
# <Feature Title>

Link To Issue Being Solved:*https://github.com/humio/python-humio/issues/17

**What Changes Have Been Made?**

Propagates `**kwargs` to the base query job's poll method
 
**Why Have the Changes Been Made?**

We can't add things like timeouts without this 

**How Do These Changes Impact the User?**

Users can add timeouts, etc. 